### PR TITLE
[Bug-fix] Adds external storage (Downloads) access for Android 10

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application
+        android:requestLegacyExternalStorage="true"
         android:icon="@mipmap/ic_launcher"
         android:label="DailyAL"
         android:enableOnBackInvokedCallback="true"


### PR DESCRIPTION
Fix for issue #29 

I know you're most likely busy with life thus I went ahead to fix the issue with backups on Android 10. It's a simple fix involving only the `AndroidManifest.xml`. Kindly review the changes and hopefully merge it if all is well.