### PR TITLE
Decode HTML entities before displaying comments and tags.

### DIFF
--- a/lib/widgets/search/filtermodal.dart
+++ b/lib/widgets/search/filtermodal.dart
@@ -516,7 +516,9 @@ class _TextFormFilterState extends State<TextFormFilter> {
   Future<void> onTap() async {
     final unescape = HtmlUnescape();
     TextEditingController _controller = TextEditingController(
-      text: unescape.convert(controller.text)
+      text: unescape
+          .convert(controller.text)
+          .replaceAll("<br />", ""),
     );
     final value = await showModalBottomSheet(
         context: context,

--- a/lib/widgets/search/filtermodal.dart
+++ b/lib/widgets/search/filtermodal.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:dailyanimelist/generated/l10n.dart';
 import 'package:intl/intl.dart';
 import 'package:dal_commons/dal_commons.dart';
+import 'package:html_unescape/html_unescape.dart';
 
 import '../../constant.dart';
 import '../custombutton.dart';
@@ -513,8 +514,10 @@ class _TextFormFilterState extends State<TextFormFilter> {
   }
 
   Future<void> onTap() async {
-    TextEditingController _controller =
-        TextEditingController(text: controller.text);
+    final unescape = HtmlUnescape();
+    TextEditingController _controller = TextEditingController(
+      text: unescape.convert(controller.text)
+    );
     final value = await showModalBottomSheet(
         context: context,
         builder: (context) {

--- a/lib/widgets/user/contenteditwidget.dart
+++ b/lib/widgets/user/contenteditwidget.dart
@@ -18,6 +18,7 @@ import 'package:dal_commons/dal_commons.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+import 'package:html_unescape/html_unescape.dart';
 
 import '../../constant.dart';
 import '../../main.dart';
@@ -876,63 +877,66 @@ class _ContentEditWidgetState extends State<ContentEditWidget> {
         ),
       );
 
-  Widget get othersWidget => Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          field(
-              S.current.Comments,
-              _modifyWidget(
-                modifyComments,
-                TextFormFilter(
-                  onFieldSubmitted: (value) {
-                    modifyComments = true;
-                    updateAdvancedStatus(
-                        comments: value,
-                        onDone: () {
-                          modifyComments = false;
-                        });
-                  },
-                  option: FilterOption(
-                      value: contentDetailed?.myListStatus?.comments,
-                      fieldName: "Comments",
-                      openTextFormAsModal: true),
-                ),
+  Widget get othersWidget {
+    final unescape = HtmlUnescape();
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        field(
+            S.current.Comments,
+            _modifyWidget(
+              modifyComments,
+              TextFormFilter(
+                onFieldSubmitted: (value) {
+                  modifyComments = true;
+                  updateAdvancedStatus(
+                      comments: value,
+                      onDone: () {
+                        modifyComments = false;
+                      });
+                },
+                option: FilterOption(
+                    value: unescape.convert(contentDetailed?.myListStatus?.comments ?? ''),
+                    fieldName: "Comments",
+                    openTextFormAsModal: true),
               ),
-              null,
-              100.0,
-              CrossAxisAlignment.start,
-              EdgeInsets.only(left: 20, bottom: 8)),
-          Padding(
-              padding: EdgeInsets.symmetric(vertical: 10),
-              child: field(
-                  S.current.Tags,
-                  _modifyWidget(
-                    modifyTags,
-                    TextFormFilter(
-                        onFieldSubmitted: (value) {
-                          modifyTags = true;
-                          updateAdvancedStatus(
-                              tags: value,
-                              onDone: () {
-                                modifyTags = false;
-                              });
-                        },
-                        option: FilterOption(
-                            value:
-                                (contentDetailed?.myListStatus?.tags != null &&
-                                        contentDetailed
-                                            .myListStatus.tags.isNotEmpty)
-                                    ? contentDetailed?.myListStatus?.tags[0]
-                                    : '',
-                            fieldName: "Tags")),
-                  ),
-                  null,
-                  null,
-                  CrossAxisAlignment.start,
-                  EdgeInsets.only(left: 20, bottom: 8))),
-        ],
-      );
+            ),
+            null,
+            100.0,
+            CrossAxisAlignment.start,
+            EdgeInsets.only(left: 20, bottom: 8)),
+        Padding(
+            padding: EdgeInsets.symmetric(vertical: 10),
+            child: field(
+                S.current.Tags,
+                _modifyWidget(
+                  modifyTags,
+                  TextFormFilter(
+                      onFieldSubmitted: (value) {
+                        modifyTags = true;
+                        updateAdvancedStatus(
+                            tags: value,
+                            onDone: () {
+                              modifyTags = false;
+                            });
+                      },
+                      option: FilterOption(
+                          value: unescape.convert(
+                              (contentDetailed?.myListStatus?.tags != null &&
+                                      contentDetailed.myListStatus.tags.isNotEmpty)
+                                  ? contentDetailed?.myListStatus?.tags[0]
+                                  : '',
+                          ),
+                          fieldName: "Tags")),
+                ),
+                null,
+                null,
+                CrossAxisAlignment.start,
+                EdgeInsets.only(left: 20, bottom: 8))),
+      ],
+    );
+  }
 
   Widget get _deleteButton {
     return Row(

--- a/lib/widgets/user/contenteditwidget.dart
+++ b/lib/widgets/user/contenteditwidget.dart
@@ -897,7 +897,9 @@ class _ContentEditWidgetState extends State<ContentEditWidget> {
                       });
                 },
                 option: FilterOption(
-                    value: unescape.convert(contentDetailed?.myListStatus?.comments ?? ''),
+                    value: unescape
+                      .convert(contentDetailed?.myListStatus?.comments ?? '')
+                      .replaceAll("<br />", ""),
                     fieldName: "Comments",
                     openTextFormAsModal: true),
               ),


### PR DESCRIPTION
For example, before apostrophes would be displayed as `&#039;` instead of `'`
This also fixes the extra line breaks `<br />` which would compound each time you would press save. Initially I wanted to replace them with `\n`, but that resulted in the same compoundment of new lines but without the br tag.